### PR TITLE
Add support for multiple reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This GitHub Action Helps with the following operations:
 | fail-label | `needs:feedback` | The label to be added to PR if the pull request doesn't pass the validation |
 | pass-label | `needs:code-review` | The label to be added to PR if the pull request pass the validation |
 | comment-template | `{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?` | Comment template for adding comment on PR if it doesn't pass the validation |
-| reviewers | `team:open-source-practice` | Reviewers to request review after passing all validation checks. Add prefix `team:` if you want to request review from the team.
+| reviewers | `team:open-source-practice` | List of Reviewers to request PR review after passing all validation checks. Add prefix `team:` if you want to request review from the team.
 
 ## Example Workflow File
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ env:
 
 **Beta:** This project is quite new and we're not sure what our ongoing support level for this will be. Bug reports, feature requests, questions, and pull requests are welcome. If you like this project please let us know, but be cautious using this in a Production environment!
 
+## Known Caveats/Issues
+
+__Fork-based PRs__ - When creating a pull request from a fork, GitHub limits the permissions of `GITHUB_TOKEN` and other API access tokens. This means that the provided `GITHUB_TOKEN` will not have write access, and the secrets will not be accessible. As a result, some operations (such as adding labels, auto-assigning pull requests, and requesting reviews automatically) will be skipped for pull requests from forked repositories, as these operations require write access to perform successfully.
+
 ## Changelog
 
 A complete listing of all notable changes to PR Automator - GitHub Action are documented in [CHANGELOG.md](https://github.com/10up/action-pr-automator/blob/develop/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This GitHub Action Helps with the following operations:
 | fail-label | `needs:feedback` | The label to be added to PR if the pull request doesn't pass the validation |
 | pass-label | `needs:code-review` | The label to be added to PR if the pull request pass the validation |
 | comment-template | `{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?` | Comment template for adding comment on PR if it doesn't pass the validation |
-| reviewer | `team:open-source-practice` | Reviewer to request review after passing all validation checks. Add prefix `team:` if you want to request review from the team.
+| reviewers | `team:open-source-practice` | Reviewers to request review after passing all validation checks. Add prefix `team:` if you want to request review from the team.
 
 ## Example Workflow File
 

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
     description: "Comment template for adding comment on PR if it doesn't pass the validation"
     required: false
     default: '{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?'
-  reviewer:
-    description: 'Reviewer to request review after passing all validation checks'
+  reviewers:
+    description: 'Reviewers to request review after passing all validation checks'
     required: false
 runs:
   using: 'node16'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: '{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?'
   reviewers:
-    description: 'Reviewers to request review after passing all validation checks'
+    description: 'List of Reviewers to request PR review after passing all validation checks'
     required: false
 runs:
   using: 'node16'

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ async function run() {
       passLabel,
       commentTemplate,
       prReviewers,
-    } = getInputs();
+    } = getInputs(pullRequest);
     core.debug(`Pull Request: ${JSON.stringify(pullRequest)}`);
     core.debug(`Is Draft: ${JSON.stringify(isDraft)}`);
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function run() {
       failLabel,
       passLabel,
       commentTemplate,
-      prReviewer,
+      prReviewers,
     } = getInputs();
     core.debug(`Pull Request: ${JSON.stringify(pullRequest)}`);
     core.debug(`Is Draft: ${JSON.stringify(isDraft)}`);
@@ -43,7 +43,7 @@ async function run() {
     if ("Bot" === author.type) {
       // Skip validation against bot user.
       await gh.addLabel(passLabel);
-      await gh.requestPRReview(prReviewer);
+      await gh.requestPRReview(prReviewers);
       return;
     }
 
@@ -61,7 +61,7 @@ async function run() {
       // Remove labels and review to handle case of switch PR back draft.
       await gh.removeLabel(labels, failLabel);
       await gh.removeLabel(labels, passLabel);
-      await gh.removePRReviewer(prReviewer, requestedReviewers);
+      await gh.removePRReviewer(prReviewers, requestedReviewers);
 
       core.info("Skipping DRAFT PR validation!");
       return;
@@ -112,7 +112,7 @@ async function run() {
     await gh.removeLabel(labels, failLabel);
     await gh.addLabel(passLabel);
     if ( requestedReviewers.length === 0 ) {
-      await gh.requestPRReview(prReviewer);
+      await gh.requestPRReview(prReviewers);
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/src/github.js
+++ b/src/github.js
@@ -165,6 +165,11 @@ export default class GitHub {
         }
       });
 
+      // Skip if no reviewers to request review.
+      if (!reviewers.reviewers?.length && !reviewers.team_reviewers?.length) {
+        return;
+      }
+
       // Request Review.
       core.info("Requesting review...");
       let requestReviewResponse = await this.octokit.pulls.requestReviewers({

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,24 +22,35 @@ export function getInputs() {
       ? false
       : core.getInput("comment-template") ||
         "{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?";
-  const prReviewer =
-    core.getInput("reviewer") === "false"
-      ? false
-      : core.getInput("reviewer") || "team:open-source-practice";
+
+  const reviewers = core.getMultilineInput("reviewers");
+  let prReviewers = reviewers[0] === "false" ? false : reviewers;
+  if (prReviewers.length === 0) {
+    // Check "reviewer" for backward compatibility.
+    const prReviewer =
+      core.getInput("reviewer") === "false" ? false : core.getInput("reviewer");
+    if (prReviewer === false) {
+      prReviewers = false;
+    } else {
+      prReviewers = prReviewer ? [prReviewer] : ["team:open-source-practice"];
+    }
+  }
 
   // Add debug log of some information.
   core.debug(`Assign PR: ${assignPullRequest} (${typeof assignPullRequest})`);
   core.debug(`Fail Label: ${failLabel} (${typeof failLabel})`);
   core.debug(`Pass Label: ${passLabel} (${typeof passLabel})`);
-  core.debug(`Comment Template: ${commentTemplate} (${typeof commentTemplate})`);
-  core.debug(`PR reviewer: ${prReviewer} (${typeof prReviewer})`);
+  core.debug(
+    `Comment Template: ${commentTemplate} (${typeof commentTemplate})`
+  );
+  core.debug(`PR reviewers: ${prReviewers} (${typeof prReviewers})`);
 
   return {
     assignPullRequest,
     failLabel,
     passLabel,
     commentTemplate,
-    prReviewer,
+    prReviewers,
   };
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,10 +3,10 @@ const core = require("@actions/core");
 /**
  * Get PR description.
  *
- * @param {object} payload Pull request payload
+ * @param {object} pullRequest Pull request payload
  * @returns string
  */
-export function getInputs() {
+export function getInputs(pullRequest) {
   const assignPullRequest =
     core.getInput("assign-pr") === "false" ? false : true;
   const failLabel =
@@ -23,6 +23,7 @@ export function getInputs() {
       : core.getInput("comment-template") ||
         "{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?";
 
+  const authorLogin = pullRequest?.user?.login;
   const reviewers = core.getMultilineInput("reviewers");
   let prReviewers = reviewers[0] === "false" ? false : reviewers;
   if (prReviewers.length === 0) {
@@ -34,6 +35,10 @@ export function getInputs() {
     } else {
       prReviewers = prReviewer ? [prReviewer] : ["team:open-source-practice"];
     }
+  }
+  core.info('Remove PR author from PR reviewers.');
+  if( prReviewers.length){
+    prReviewers = prReviewers.filter((reviewer) => reviewer !== authorLogin);
   }
 
   // Add debug log of some information.


### PR DESCRIPTION
### Description of the Change
Currently, action has support for request review from a single reviewer, This PR adds support for request review from multiple reviewers. 

Closes #44 
### How to test the Change
1. Create a PR Automator workflow
2. Add multiple users/teams in the `reviewers` configuration field. like below:
```
reviewers: |
  iamdharmesh
  ghuser1
  ghuser2
  team:test
```
3. Create a sample PR 
4. Verify review is requested from all reviewers.

### Changelog Entry
> Added - Support for multiple PR reviewers.
> Changed - Renamed `reviewer` configuration field to `reviewers`.

### Credits
Props @iamdharmesh.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
