### PR TITLE
Add support for assign closing issues of PR to PR author.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 This GitHub Action Helps with the following operations:
 - **Validate PR description:** It validates PR description to make sure it contains description of the change, changelog and credits. Also, you can set custom comment message for PR author to inform them about PR description requirements.
 - **Add Labels:** It helps with adding label to PR when PR validation pass or fail.
+- **Auto-assign Issues:** This feature helps to automatically assign closing issues of PR to the PR author.
 - **Auto-assign PR:** It helps with assigning PR to the author.
 - **Auto request review:** It helps with request review from the team or GitHub user given in the configuration.
 
@@ -21,7 +22,8 @@ This GitHub Action Helps with the following operations:
 
 | Key | Default | Description |
 | --- | ------- | ----------- |
-| assign-pr | true | Wether assign PR to reporter |
+| assign-pr | true | Whether assign PR to reporter |
+| assign-issues | true | Whether assign closing issues of PR to the PR author |
 | fail-label | `needs:feedback` | The label to be added to PR if the pull request doesn't pass the validation |
 | pass-label | `needs:code-review` | The label to be added to PR if the pull request pass the validation |
 | comment-template | `{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?` | Comment template for adding comment on PR if it doesn't pass the validation |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This GitHub Action Helps with the following operations:
 - **Validate PR description:** It validates PR description to make sure it contains description of the change, changelog and credits. Also, you can set custom comment message for PR author to inform them about PR description requirements.
 - **Add Labels:** It helps with adding label to PR when PR validation pass or fail.
-- **Auto-assign Issues:** This feature helps to automatically assign closing issues of PR to the PR author.
+- **Auto-assign Issues:** This feature helps to automatically assign issue with PR assignee when a linked PR is merged.
 - **Auto-assign PR:** It helps with assigning PR to the author.
 - **Auto request review:** It helps with request review from the team or GitHub user given in the configuration.
 
@@ -22,8 +22,8 @@ This GitHub Action Helps with the following operations:
 
 | Key | Default | Description |
 | --- | ------- | ----------- |
-| assign-pr | true | Whether assign PR to reporter |
-| assign-issues | true | Whether assign closing issues of PR to the PR author |
+| assign-pr | true | Whether to assign PR to author |
+| assign-issues | true | Whether to assign issue with PR assignee when linked PR is merged |
 | fail-label | `needs:feedback` | The label to be added to PR if the pull request doesn't pass the validation |
 | pass-label | `needs:code-review` | The label to be added to PR if the pull request pass the validation |
 | comment-template | `{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?` | Comment template for adding comment on PR if it doesn't pass the validation |

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,11 @@ branding:
   color: 'blue'
 inputs:
   assign-pr:
-    description: "Wether assign PR to reporter"
+    description: "Whether assign PR to reporter"
+    required: false
+    default: true
+  assign-issues:
+    description: "Whether assign closing issues of PR to the PR author"
     required: false
     default: true
   fail-label:

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,11 @@ branding:
   color: 'blue'
 inputs:
   assign-pr:
-    description: "Whether assign PR to reporter"
+    description: "Whether to assign PR to author"
     required: false
     default: true
   assign-issues:
-    description: "Whether assign closing issues of PR to the PR author"
+    description: "Whether to assign closing issue with PR assignee when linked PR is merged"
     required: false
     default: true
   fail-label:

--- a/dist/index.js
+++ b/dist/index.js
@@ -14136,7 +14136,7 @@ class GitHub {
         );
       }
     } catch (error) {
-      core.info(`Failed assigned PR to (${prAuthor.login}) : ${error}`);
+      core.info(`Failed assign issues to (${prAuthor.login}) : ${error}`);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ async function run() {
     } = pullRequest;
 
     const {
+      assignIssues,
       assignPullRequest,
       failLabel,
       passLabel,
@@ -54,6 +55,12 @@ async function run() {
     ) {
       core.info("PR is unassigned, assigning PR");
       await gh.assignPR(author);
+    }
+
+    // Assign Issues to author
+    if (assignIssues) {
+      core.info("Assigning issues to PR author");
+      await gh.assignIssues(author);
     }
 
     // Skip Draft PR

--- a/src/github.js
+++ b/src/github.js
@@ -249,7 +249,7 @@ export default class GitHub {
         );
       }
     } catch (error) {
-      core.info(`Failed assigned PR to (${prAuthor.login}) : ${error}`);
+      core.info(`Failed assign issues to (${prAuthor.login}) : ${error}`);
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,8 @@ const core = require("@actions/core");
  * @returns string
  */
 export function getInputs() {
+  const assignIssues =
+    core.getInput("assign-issues") === "false" ? false : true;
   const assignPullRequest =
     core.getInput("assign-pr") === "false" ? false : true;
   const failLabel =
@@ -28,13 +30,17 @@ export function getInputs() {
       : core.getInput("reviewer") || "team:open-source-practice";
 
   // Add debug log of some information.
+  core.debug(`Assign Issues: ${assignIssues} (${typeof assignIssues})`);
   core.debug(`Assign PR: ${assignPullRequest} (${typeof assignPullRequest})`);
   core.debug(`Fail Label: ${failLabel} (${typeof failLabel})`);
   core.debug(`Pass Label: ${passLabel} (${typeof passLabel})`);
-  core.debug(`Comment Template: ${commentTemplate} (${typeof commentTemplate})`);
+  core.debug(
+    `Comment Template: ${commentTemplate} (${typeof commentTemplate})`
+  );
   core.debug(`PR reviewer: ${prReviewer} (${typeof prReviewer})`);
 
   return {
+    assignIssues,
     assignPullRequest,
     failLabel,
     passLabel,


### PR DESCRIPTION
### Description of the Change
PR adds support for assigning closing issues of PR to the PR author.

Closes #46 

### How to test the Change
1. Create a PR Automator workflow
2. Create a sample issue and create a sample PR to fix that issue.
3. Verify issue is auto-assigned to the PR author.

### Changelog Entry
> Added - Support for auto-assigning issue with PR assignee when linked PR is merged.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
