### PR TITLE
Skip merge conflict check and Auto-sync on PRs from Bots

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36909,6 +36909,7 @@ class GitHub {
               locked
               author {
                 login
+                __typename
               }
               baseRefOid
               baseRef {
@@ -36961,6 +36962,7 @@ class GitHub {
           locked
           author {
             login
+            __typename
           }
           baseRefOid
           baseRef {
@@ -37151,9 +37153,9 @@ class PRConflict {
     if (
       locked ||
       mergeable === "UNKNOWN" ||
-      author.login === "dependabot[bot]"
+      "Bot" === author?.__typename
     ) {
-      // Skip locked PRs, PRs with unknown mergeable state, and dependabot PRs
+      // Skip locked PRs, PRs with unknown mergeable state, and PRs from Bots.
       return;
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -37156,6 +37156,7 @@ class PRConflict {
       "Bot" === author?.__typename
     ) {
       // Skip locked PRs, PRs with unknown mergeable state, and PRs from Bots.
+      pr_conflict_core.info("Skipping... Either the PR is from a Bot User, has an unknown mergeable state, or is locked.");
       return;
     }
 

--- a/src/github.js
+++ b/src/github.js
@@ -525,6 +525,7 @@ export default class GitHub {
               locked
               author {
                 login
+                __typename
               }
               baseRefOid
               baseRef {
@@ -577,6 +578,7 @@ export default class GitHub {
           locked
           author {
             login
+            __typename
           }
           baseRefOid
           baseRef {

--- a/src/pr-conflict.js
+++ b/src/pr-conflict.js
@@ -93,9 +93,9 @@ export default class PRConflict {
     if (
       locked ||
       mergeable === "UNKNOWN" ||
-      author.login === "dependabot[bot]"
+      "Bot" === author?.__typename
     ) {
-      // Skip locked PRs, PRs with unknown mergeable state, and dependabot PRs
+      // Skip locked PRs, PRs with unknown mergeable state, and PRs from Bots.
       return;
     }
 

--- a/src/pr-conflict.js
+++ b/src/pr-conflict.js
@@ -96,6 +96,7 @@ export default class PRConflict {
       "Bot" === author?.__typename
     ) {
       // Skip locked PRs, PRs with unknown mergeable state, and PRs from Bots.
+      core.info("Skipping... Either the PR is from a Bot User, has an unknown mergeable state, or is locked.");
       return;
     }
 


### PR DESCRIPTION
### Description of the Change
PR contains changes to skip merge conflict checks and Auto-sync on PRs from Bots. Autosync Bot's PR can create an issue with rebase and other operations supported by a bot as reported in the issue.

Closes #97

### How to test the Change
1. Setup this action on the repo with `sync-pr-branch: true`
2. Make sure the repo has at least 1 PR from the bot user (eg: PR from [dependabot](https://github.com/apps/dependabot))
3. Push anything to the target branch
4. Make sure PR from the bot user is not synced with the target branch

I have tested this on one of my repo and action logs can be found [here](https://github.com/iamdharmesh/action-pr-helper-test/actions/runs/6432329578/job/17466954360)

### Changelog Entry
> Changed - Skip merge conflict check and Auto-sync on pull requests from bots.

### Credits
Props @peterwilsoncc @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
