### PR TITLE
Fix most reported code scanning alerts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7383,6 +7383,179 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
+/***/ 7676:
+/***/ ((module) => {
+
+/**
+ * lodash (Custom Build) <https://lodash.com/>
+ * Build: `lodash modularize exports="npm" -o ./`
+ * Copyright jQuery Foundation and other contributors <https://jquery.org/>
+ * Released under MIT license <https://lodash.com/license>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ */
+
+/** Used as references for various `Number` constants. */
+var INFINITY = 1 / 0;
+
+/** `Object#toString` result references. */
+var symbolTag = '[object Symbol]';
+
+/**
+ * Used to match `RegExp`
+ * [syntax characters](http://ecma-international.org/ecma-262/6.0/#sec-patterns).
+ */
+var reRegExpChar = /[\\^$.*+?()[\]{}|]/g,
+    reHasRegExpChar = RegExp(reRegExpChar.source);
+
+/** Detect free variable `global` from Node.js. */
+var freeGlobal = typeof global == 'object' && global && global.Object === Object && global;
+
+/** Detect free variable `self`. */
+var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+
+/** Used as a reference to the global object. */
+var root = freeGlobal || freeSelf || Function('return this')();
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/**
+ * Used to resolve the
+ * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * of values.
+ */
+var objectToString = objectProto.toString;
+
+/** Built-in value references. */
+var Symbol = root.Symbol;
+
+/** Used to convert symbols to primitives and strings. */
+var symbolProto = Symbol ? Symbol.prototype : undefined,
+    symbolToString = symbolProto ? symbolProto.toString : undefined;
+
+/**
+ * The base implementation of `_.toString` which doesn't convert nullish
+ * values to empty strings.
+ *
+ * @private
+ * @param {*} value The value to process.
+ * @returns {string} Returns the string.
+ */
+function baseToString(value) {
+  // Exit early for strings to avoid a performance hit in some environments.
+  if (typeof value == 'string') {
+    return value;
+  }
+  if (isSymbol(value)) {
+    return symbolToString ? symbolToString.call(value) : '';
+  }
+  var result = (value + '');
+  return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
+}
+
+/**
+ * Checks if `value` is object-like. A value is object-like if it's not `null`
+ * and has a `typeof` result of "object".
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
+ * @example
+ *
+ * _.isObjectLike({});
+ * // => true
+ *
+ * _.isObjectLike([1, 2, 3]);
+ * // => true
+ *
+ * _.isObjectLike(_.noop);
+ * // => false
+ *
+ * _.isObjectLike(null);
+ * // => false
+ */
+function isObjectLike(value) {
+  return !!value && typeof value == 'object';
+}
+
+/**
+ * Checks if `value` is classified as a `Symbol` primitive or object.
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
+ * @example
+ *
+ * _.isSymbol(Symbol.iterator);
+ * // => true
+ *
+ * _.isSymbol('abc');
+ * // => false
+ */
+function isSymbol(value) {
+  return typeof value == 'symbol' ||
+    (isObjectLike(value) && objectToString.call(value) == symbolTag);
+}
+
+/**
+ * Converts `value` to a string. An empty string is returned for `null`
+ * and `undefined` values. The sign of `-0` is preserved.
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to process.
+ * @returns {string} Returns the string.
+ * @example
+ *
+ * _.toString(null);
+ * // => ''
+ *
+ * _.toString(-0);
+ * // => '-0'
+ *
+ * _.toString([1, 2, 3]);
+ * // => '1,2,3'
+ */
+function toString(value) {
+  return value == null ? '' : baseToString(value);
+}
+
+/**
+ * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+",
+ * "?", "(", ")", "[", "]", "{", "}", and "|" in `string`.
+ *
+ * @static
+ * @memberOf _
+ * @since 3.0.0
+ * @category String
+ * @param {string} [string=''] The string to escape.
+ * @returns {string} Returns the escaped string.
+ * @example
+ *
+ * _.escapeRegExp('[lodash](https://lodash.com/)');
+ * // => '\[lodash\]\(https://lodash\.com/\)'
+ */
+function escapeRegExp(string) {
+  string = toString(string);
+  return (string && reHasRegExpChar.test(string))
+    ? string.replace(reRegExpChar, '\\$&')
+    : string;
+}
+
+module.exports = escapeRegExp;
+
+
+/***/ }),
+
 /***/ 1223:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -29861,7 +30034,7 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony export */   "wait": () => (/* binding */ wait)
 /* harmony export */ });
 const core = __nccwpck_require__(2186);
-const escapeRegExp = __nccwpck_require__(2829);
+const escapeRegExp = __nccwpck_require__(7676);
 
 /**
  * Get inputs from workflow file.
@@ -30130,14 +30303,6 @@ function removeHtmlComments(input) {
 
   return input;
 }
-
-
-/***/ }),
-
-/***/ 2829:
-/***/ ((module) => {
-
-module.exports = eval("require")("lodash.escaperegexp");
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -29861,6 +29861,7 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony export */   "wait": () => (/* binding */ wait)
 /* harmony export */ });
 const core = __nccwpck_require__(2186);
+const escapeRegExp = __nccwpck_require__(2829);
 
 /**
  * Get inputs from workflow file.
@@ -30020,13 +30021,13 @@ function getInputs(pullRequest = {}) {
 
 /**
  * Get Matches from string based on regex
- * 
- * @param {string} string 
- * @param {string} validationRegex 
- * @returns 
+ *
+ * @param {string} string
+ * @param {string} validationRegex
+ * @returns
  */
 function getMatches(string, validationRegex) {
-  const regex = new RegExp(validationRegex);
+  const regex = new RegExp(escapeRegExp(validationRegex));
   return regex.exec(string);
 }
 
@@ -30038,7 +30039,7 @@ function getMatches(string, validationRegex) {
  */
 function getDescription(payload, validationRegex) {
   let description = "";
-  const cleanBody = payload?.body?.replace(/<!--.*?-->/gs, "");
+  const cleanBody = removeHtmlComments(payload?.body || '');
   const matches = getMatches(cleanBody, validationRegex);
   if (matches !== null) {
     description = matches[1]
@@ -30057,7 +30058,7 @@ function getDescription(payload, validationRegex) {
  * @returns array
  */
 function getCredits(payload, validationRegex) {
-  const cleanBody = payload?.body?.replace(/<!--.*?-->/gs, "");
+  const cleanBody = removeHtmlComments(payload?.body || '');
   let credits = [];
   const matches = getMatches(cleanBody, validationRegex);
   if (matches !== null) {
@@ -30084,7 +30085,7 @@ function getCredits(payload, validationRegex) {
  */
 function getChangelog(payload, validationRegex) {
   let entries = [];
-  const cleanBody = payload?.body?.replace(/<!--.*?-->/gs, "");
+  const cleanBody = removeHtmlComments(payload?.body || '');
   const matches = getMatches(cleanBody, validationRegex);
   if (matches !== null) {
     const changelog = matches[1];
@@ -30113,6 +30114,30 @@ function versionCompare(a, b) {
 function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+/**
+ * Remove all HTML comments from a string.
+ *
+ * @param {string} input Input string.
+ * @returns string
+ */
+function removeHtmlComments(input) {
+  let previous;
+  do {
+    previous = input;
+    input = input?.replace(/<!--.*?-->/gs, "");
+  } while (input !== previous);
+
+  return input;
+}
+
+
+/***/ }),
+
+/***/ 2829:
+/***/ ((module) => {
+
+module.exports = eval("require")("lodash.escaperegexp");
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -7383,179 +7383,6 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 7676:
-/***/ ((module) => {
-
-/**
- * lodash (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright jQuery Foundation and other contributors <https://jquery.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- */
-
-/** Used as references for various `Number` constants. */
-var INFINITY = 1 / 0;
-
-/** `Object#toString` result references. */
-var symbolTag = '[object Symbol]';
-
-/**
- * Used to match `RegExp`
- * [syntax characters](http://ecma-international.org/ecma-262/6.0/#sec-patterns).
- */
-var reRegExpChar = /[\\^$.*+?()[\]{}|]/g,
-    reHasRegExpChar = RegExp(reRegExpChar.source);
-
-/** Detect free variable `global` from Node.js. */
-var freeGlobal = typeof global == 'object' && global && global.Object === Object && global;
-
-/** Detect free variable `self`. */
-var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
-
-/** Used as a reference to the global object. */
-var root = freeGlobal || freeSelf || Function('return this')();
-
-/** Used for built-in method references. */
-var objectProto = Object.prototype;
-
-/**
- * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
- * of values.
- */
-var objectToString = objectProto.toString;
-
-/** Built-in value references. */
-var Symbol = root.Symbol;
-
-/** Used to convert symbols to primitives and strings. */
-var symbolProto = Symbol ? Symbol.prototype : undefined,
-    symbolToString = symbolProto ? symbolProto.toString : undefined;
-
-/**
- * The base implementation of `_.toString` which doesn't convert nullish
- * values to empty strings.
- *
- * @private
- * @param {*} value The value to process.
- * @returns {string} Returns the string.
- */
-function baseToString(value) {
-  // Exit early for strings to avoid a performance hit in some environments.
-  if (typeof value == 'string') {
-    return value;
-  }
-  if (isSymbol(value)) {
-    return symbolToString ? symbolToString.call(value) : '';
-  }
-  var result = (value + '');
-  return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
-}
-
-/**
- * Checks if `value` is object-like. A value is object-like if it's not `null`
- * and has a `typeof` result of "object".
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
- * @example
- *
- * _.isObjectLike({});
- * // => true
- *
- * _.isObjectLike([1, 2, 3]);
- * // => true
- *
- * _.isObjectLike(_.noop);
- * // => false
- *
- * _.isObjectLike(null);
- * // => false
- */
-function isObjectLike(value) {
-  return !!value && typeof value == 'object';
-}
-
-/**
- * Checks if `value` is classified as a `Symbol` primitive or object.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
- * @example
- *
- * _.isSymbol(Symbol.iterator);
- * // => true
- *
- * _.isSymbol('abc');
- * // => false
- */
-function isSymbol(value) {
-  return typeof value == 'symbol' ||
-    (isObjectLike(value) && objectToString.call(value) == symbolTag);
-}
-
-/**
- * Converts `value` to a string. An empty string is returned for `null`
- * and `undefined` values. The sign of `-0` is preserved.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to process.
- * @returns {string} Returns the string.
- * @example
- *
- * _.toString(null);
- * // => ''
- *
- * _.toString(-0);
- * // => '-0'
- *
- * _.toString([1, 2, 3]);
- * // => '1,2,3'
- */
-function toString(value) {
-  return value == null ? '' : baseToString(value);
-}
-
-/**
- * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+",
- * "?", "(", ")", "[", "]", "{", "}", and "|" in `string`.
- *
- * @static
- * @memberOf _
- * @since 3.0.0
- * @category String
- * @param {string} [string=''] The string to escape.
- * @returns {string} Returns the escaped string.
- * @example
- *
- * _.escapeRegExp('[lodash](https://lodash.com/)');
- * // => '\[lodash\]\(https://lodash\.com/\)'
- */
-function escapeRegExp(string) {
-  string = toString(string);
-  return (string && reHasRegExpChar.test(string))
-    ? string.replace(reRegExpChar, '\\$&')
-    : string;
-}
-
-module.exports = escapeRegExp;
-
-
-/***/ }),
-
 /***/ 1223:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -30034,7 +29861,6 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony export */   "wait": () => (/* binding */ wait)
 /* harmony export */ });
 const core = __nccwpck_require__(2186);
-const escapeRegExp = __nccwpck_require__(7676);
 
 /**
  * Get inputs from workflow file.
@@ -30200,7 +30026,7 @@ function getInputs(pullRequest = {}) {
  * @returns
  */
 function getMatches(string, validationRegex) {
-  const regex = new RegExp(escapeRegExp(validationRegex));
+  const regex = new RegExp(validationRegex);
   return regex.exec(string);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
-        "@octokit/action": "^6.0.6"
+        "@octokit/action": "^6.0.6",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.38.1",
@@ -1048,6 +1049,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2230,6 +2236,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
-        "@octokit/action": "^6.0.6",
-        "lodash.escaperegexp": "^4.1.2"
+        "@octokit/action": "^6.0.6"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.38.1",
@@ -1049,11 +1048,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2236,11 +2230,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
         "@octokit/action": "^6.0.6",
-        "lodash": "^4.17.21"
+        "lodash.escaperegexp": "^4.1.2"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.38.1",
@@ -1050,10 +1050,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2237,10 +2237,10 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
-    "@octokit/action": "^6.0.6",
-    "lodash.escaperegexp": "^4.1.2"
+    "@octokit/action": "^6.0.6"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
-    "@octokit/action": "^6.0.6"
-  },  
+    "@octokit/action": "^6.0.6",
+    "lodash": "^4.17.21"
+  },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1",
     "eslint": "^8.52.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
     "@octokit/action": "^6.0.6",
-    "lodash": "^4.17.21"
+    "lodash.escaperegexp": "^4.1.2"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1",

--- a/src/utils.js
+++ b/src/utils.js
@@ -176,7 +176,7 @@ function getMatches(string, validationRegex) {
  */
 export function getDescription(payload, validationRegex) {
   let description = "";
-  const cleanBody = payload?.body?.replace(/<!--.*?-->/gs, "");
+  const cleanBody = removeHtmlComments(payload?.body || '');
   const matches = getMatches(cleanBody, validationRegex);
   if (matches !== null) {
     description = matches[1]
@@ -195,7 +195,7 @@ export function getDescription(payload, validationRegex) {
  * @returns array
  */
 export function getCredits(payload, validationRegex) {
-  const cleanBody = payload?.body?.replace(/<!--.*?-->/gs, "");
+  const cleanBody = removeHtmlComments(payload?.body || '');
   let credits = [];
   const matches = getMatches(cleanBody, validationRegex);
   if (matches !== null) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 const core = require("@actions/core");
+const escapeRegExp = require("lodash.escaperegexp");
 
 /**
  * Get inputs from workflow file.
@@ -164,7 +165,7 @@ export function getInputs(pullRequest = {}) {
  * @returns
  */
 function getMatches(string, validationRegex) {
-  const regex = new RegExp(validationRegex);
+  const regex = new RegExp(escapeRegExp(validationRegex));
   return regex.exec(string);
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -158,10 +158,10 @@ export function getInputs(pullRequest = {}) {
 
 /**
  * Get Matches from string based on regex
- * 
- * @param {string} string 
- * @param {string} validationRegex 
- * @returns 
+ *
+ * @param {string} string
+ * @param {string} validationRegex
+ * @returns
  */
 function getMatches(string, validationRegex) {
   const regex = new RegExp(validationRegex);
@@ -222,7 +222,7 @@ export function getCredits(payload, validationRegex) {
  */
 export function getChangelog(payload, validationRegex) {
   let entries = [];
-  const cleanBody = payload?.body?.replace(/<!--.*?-->/gs, "");
+  const cleanBody = removeHtmlComments(payload?.body || '');
   const matches = getMatches(cleanBody, validationRegex);
   if (matches !== null) {
     const changelog = matches[1];
@@ -250,4 +250,20 @@ export function versionCompare(a, b) {
 
 export function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Remove all HTML comments from a string.
+ *
+ * @param {string} input Input string.
+ * @returns string
+ */
+function removeHtmlComments(input) {
+  let previous;
+  do {
+    previous = input;
+    input = input?.replace(/<!--.*?-->/gs, "");
+  } while (input !== previous);
+
+  return input;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 const core = require("@actions/core");
-const escapeRegExp = require("lodash.escaperegexp");
 
 /**
  * Get inputs from workflow file.
@@ -165,7 +164,7 @@ export function getInputs(pullRequest = {}) {
  * @returns
  */
 function getMatches(string, validationRegex) {
-  const regex = new RegExp(escapeRegExp(validationRegex));
+  const regex = new RegExp(validationRegex);
   return regex.exec(string);
 }
 


### PR DESCRIPTION
### Description of the Change

This PR fixes most of the code scanning reports as seen [here](https://github.com/10up/action-repo-automator/security/code-scanning).

There are four reports there but three of them are the same, which this PR fixes those three:

- Ensure that when we sanitize input to remove HTML comments, we account for instances where multiple comments may be nested. All of those should be removed, not just the first instance

The remaining issue is around using user input for a regular expression. The suggested fix (using `lodash` to escape that) breaks our regular expression (see https://github.com/10up/action-repo-automator/pull/108#pullrequestreview-1701985570), so a different approach will need to be taken there.

### How to test the Change

Not sure the best way to test this locally

### Changelog Entry

> Fixed - Ensure we properly remove all HTML comments from input strings.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
