### PR TITLE
Dependabot disable version updates for GitHub Actions and npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 0
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### Description of the Change
PR updates Dependabot config to disable version updates for GitHub Actions and npm dependencies and keep version updates enable only for security updates.

### How to test the Change
NA

### Changelog Entry
> Changed - Disabled dependabot version updates for GitHub Actions and npm dependencies

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh @jeffpaul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
