### PR TITLE
Exclude the release pull request from the PR validations.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32203,7 +32203,7 @@ async function pull_request_run() {
     pull_request_core.debug(`Is Draft: ${JSON.stringify(isDraft)}`);
 
     // Ignore release PRs.
-    if ( pullRequest?.head.ref && pullRequest?.head.ref.startsWith("release/") ) {
+    if (pullRequest?.head.ref && pullRequest?.head.ref.startsWith("release/")) {
       pull_request_core.info("Skipping release PR");
       return;
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -32202,6 +32202,12 @@ async function pull_request_run() {
     pull_request_core.debug(`Pull Request: ${JSON.stringify(pullRequest)}`);
     pull_request_core.debug(`Is Draft: ${JSON.stringify(isDraft)}`);
 
+    // Ignore release PRs.
+    if ( pullRequest?.head.ref && pullRequest?.head.ref.startsWith("release/") ) {
+      pull_request_core.info("Skipping release PR");
+      return;
+    }
+
     // Handle Bot User
     if ("Bot" === author?.type) {
       // Skip validation against bot user.

--- a/src/pull-request.js
+++ b/src/pull-request.js
@@ -48,7 +48,7 @@ export async function run() {
     core.debug(`Is Draft: ${JSON.stringify(isDraft)}`);
 
     // Ignore release PRs.
-    if ( pullRequest?.head.ref && pullRequest?.head.ref.startsWith("release/") ) {
+    if (pullRequest?.head.ref && pullRequest?.head.ref.startsWith("release/")) {
       core.info("Skipping release PR");
       return;
     }

--- a/src/pull-request.js
+++ b/src/pull-request.js
@@ -47,6 +47,12 @@ export async function run() {
     core.debug(`Pull Request: ${JSON.stringify(pullRequest)}`);
     core.debug(`Is Draft: ${JSON.stringify(isDraft)}`);
 
+    // Ignore release PRs.
+    if ( pullRequest?.head.ref && pullRequest?.head.ref.startsWith("release/") ) {
+      core.info("Skipping release PR");
+      return;
+    }
+
     // Handle Bot User
     if ("Bot" === author?.type) {
       // Skip validation against bot user.


### PR DESCRIPTION
### Description of the Change
PR makes changes in action to Exclude the release pull request from the PR validations.

### How to test the Change
1. Add workflow to the repository using this action @ PR branch. (you can use any repo for the test)
1. Raise the release PR to repo
1. Vefiry PR validation skipped on that PR.

 I have tested this on test repo [here](https://github.com/iamdharmesh/action-pr-helper-test/pull/24) and here is the [job log](https://github.com/iamdharmesh/action-pr-helper-test/actions/runs/8206292455/job/22445052982?pr=24)

### Changelog Entry
> Changed - Exclude the release pull request from the PR validations.


### Credits
Props @iamdharmesh @dkotter (Thanks for feedback on this @dkotter )


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
