### PR TITLE
Add configurable PR template section validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This GitHub Action Helps with the following operations:
 | fail-label | `needs:feedback` | The label to be added to PR if the pull request doesn't pass the validation. Pass `false` to skip adding the label. |
 | pass-label | `needs:code-review` | The label to be added to PR if the pull request pass the validation. Pass `false` to skip adding the label. |
 | conflict-label | `needs:refresh` | The label to be added to PR if the pull request has conflicts. Pass `false` to skip adding the label. |
-| comment-template | `{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?` | Comment template for adding comment on PR if it doesn't pass the validation. Pass `false` to skip adding the comment. |
+| comment-template | `{author} thanks for the PR! Could you please fill out the PR template so that we can properly review and merge this?` | Comment template for adding comment on PR if it doesn't pass the validation. Pass `false` to skip adding the comment. |
 | conflict-comment | `{author} thanks for the PR! Could you please rebase your PR on top of the latest changes in the base branch?` | Comment template for adding comment on PR if it has conflicts. Pass `false` to skip adding the comment. |
 | issue-welcome-message | false | Comment template for adding a welcome message on an issue for first-time issue creators |
 | pr-welcome-message | false | Comment template for adding a welcome message on a PR for first-time PR creators |
@@ -48,8 +48,33 @@ This GitHub Action Helps with the following operations:
 | validate-description | true | Whether to validate the pull request description. Pass `false` to disable description validation |
 | validate-changelog | true | Whether to validate the pull request changelog entry. Pass `false` to disable changelog validation |
 | validate-credits | true | Whether to validate the props given in pull request. Pass `false` to disable credits validation |
+| validate-pr-template-sections | - | Multiline list of PR template section headings (without `#` markers) that must have non-empty content. Heading level is ignored, so `What?`, `## Why?`, and `### Use of AI Tools` all work the same way. See [PR Template Section Validation](#pr-template-section-validation) for details. |
 | wait-ms | `15000` | Time to wait in milliseconds between retries to check PR mergeable status |
 | max-retries | `5` | Maximum number of retries to check PR mergeable status |
+
+## PR Template Section Validation
+
+The `validate-pr-template-sections` input lets you validate that specific sections of your repository's PR template have been filled out. This is an alternative to the built-in `validate-description`, `validate-changelog`, and `validate-credits` checks, and is useful when your PR template uses different headings or sections than those defaults.
+
+Provide a multiline list of section heading names (without the `#` markers). The heading level is ignored — `What?`, `## Why?`, and `### Use of AI Tools` all resolve to the same heading text. Content under a section is considered empty if it contains only whitespace or blockquote lines (lines starting with `>`), which are commonly used as placeholder examples in PR templates.
+
+For example, to require that contributors fill out the `What?`, `Why?`, and `Use of AI Tools` sections of a custom PR template:
+
+```yml
+- uses: 10up/action-repo-automator@trunk
+  with:
+    validate-description: false
+    validate-changelog: false
+    validate-credits: false
+    validate-pr-template-sections: |
+      What?
+      Why?
+      Use of AI Tools
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Each section that fails validation will produce a separate error and contribute to the `fail-label` being applied to the PR.
 
 ## Example Workflow File
 

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
   comment-template:
     description: "Comment template for adding comment on PR if it doesn't pass the validation"
     required: false
-    default: "{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?"
+    default: "{author} thanks for the PR! Could you please fill out the PR template so that we can properly review and merge this?"
   issue-welcome-message:
     description: "Comment template for adding a welcome message on an issue for first-time issue creators"
     required: false
@@ -58,6 +58,10 @@ inputs:
     description: "Whether to enable automatic synchronization of the pull request branch with the base branch"
     required: false
     default: false
+  validate-pr-template-sections:
+    description: "Multiline list of PR template section headings (without # markers) that must have non-empty content. Heading level is ignored, so 'What?', '## Why?', and '### Use of AI Tools' all work. Defaults to empty (disabled)."
+    required: false
+    default: ""
   validate-description:
     description: "Whether to validate the pull request description"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -58572,6 +58572,7 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony export */   getCredits: () => (/* binding */ getCredits),
 /* harmony export */   getDescription: () => (/* binding */ getDescription),
 /* harmony export */   getInputs: () => (/* binding */ getInputs),
+/* harmony export */   getSectionContent: () => (/* binding */ getSectionContent),
 /* harmony export */   versionCompare: () => (/* binding */ versionCompare),
 /* harmony export */   wait: () => (/* binding */ wait)
 /* harmony export */ });
@@ -58612,7 +58613,13 @@ function getInputs(pullRequest = {}) {
     core.getInput("comment-template") === "false"
       ? false
       : core.getInput("comment-template") ||
-        "{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?";
+        "{author} thanks for the PR! Could you please fill out the PR template so that we can properly review and merge this?";
+
+  // PR template section validation
+  const rawTemplateSections = core.getMultilineInput("validate-pr-template-sections") || [];
+  const validatePRTemplateSections = rawTemplateSections
+    .map((s) => s.replace(/^#+\s*/, "").trim())
+    .filter(Boolean);
 
   // Welcome message inputs
   const issueWelcomeMessage =
@@ -58710,9 +58717,13 @@ function getInputs(pullRequest = {}) {
     `PR Welcome Message: ${prWelcomeMessage} (${typeof prWelcomeMessage})`
   );
   core.debug(`Ignore Users: ${ignoreUsers} (${typeof ignoreUsers})`);
+  core.debug(
+    `Validate PR Template Sections: ${validatePRTemplateSections} (${typeof validatePRTemplateSections})`
+  );
 
   return {
     assignIssues,
+    validatePRTemplateSections,
     addMilestone,
     assignPullRequest,
     validateChangelog,
@@ -58797,6 +58808,44 @@ function getChangelog(payload) {
   }
 
   return entries.filter((entry) => entry.length > 0);
+}
+
+/**
+ * Get the content under a specific section heading in the PR body.
+ * Matches any heading level (e.g. #, ##, ###) followed by the given heading text.
+ *
+ * @param {object} payload     Pull request payload
+ * @param {string} headingName Section heading text, without leading # markers
+ * @returns string
+ */
+function getSectionContent(payload, headingName) {
+  const cleanBody = removeHtmlComments(payload?.body || "");
+  const lines = cleanBody.split(/\r?\n/);
+  let inSection = false;
+  const content = [];
+
+  for (const line of lines) {
+    const isHeading = /^#{1,6}\s+/.test(line);
+    if (isHeading) {
+      // Stop collecting once we hit the next heading after our target.
+      if (inSection) {
+        break;
+      }
+      // Start collecting if this heading matches the target (any level).
+      if (line.replace(/^#{1,6}\s+/, "").trim() === headingName) {
+        inSection = true;
+      }
+      continue;
+    }
+    if (inSection) {
+      content.push(line);
+    }
+  }
+
+  return content
+    .filter((line) => !/^>\s/.test(line))
+    .join("\n")
+    .trim();
 }
 
 /**
@@ -64113,6 +64162,7 @@ const {
   getCredits,
   getDescription,
   getInputs: pr_validation_getInputs,
+  getSectionContent,
 } = __nccwpck_require__(5804);
 
 class PRValidation {
@@ -64141,9 +64191,15 @@ class PRValidation {
       validateChangelog,
       validateCredits,
       validateDescription,
+      validatePRTemplateSections,
     } = pr_validation_getInputs();
 
-    if (!validateChangelog && !validateCredits && !validateDescription) {
+    if (
+      !validateChangelog &&
+      !validateCredits &&
+      !validateDescription &&
+      !validatePRTemplateSections.length
+    ) {
       pr_validation_core.info("PR validation is disabled");
       return;
     }
@@ -64177,6 +64233,20 @@ class PRValidation {
       if (!description.length) {
         failed = true;
         errors.push("Please add some description about the changes made in PR");
+      }
+    }
+
+    if (validatePRTemplateSections.length) {
+      pr_validation_core.info("Running PR template section validation");
+      for (const heading of validatePRTemplateSections) {
+        const content = getSectionContent(pullRequest, heading);
+        pr_validation_core.debug(`Section "${heading}": ${content}`);
+        if (!content.length) {
+          failed = true;
+          errors.push(
+            `Please fill out the **${heading}** section of the PR template`
+          );
+        }
       }
     }
 

--- a/src/pr-validation.js
+++ b/src/pr-validation.js
@@ -6,6 +6,7 @@ const {
   getCredits,
   getDescription,
   getInputs,
+  getSectionContent,
 } = require("./utils.js");
 
 export default class PRValidation {
@@ -34,9 +35,15 @@ export default class PRValidation {
       validateChangelog,
       validateCredits,
       validateDescription,
+      validatePRTemplateSections,
     } = getInputs();
 
-    if (!validateChangelog && !validateCredits && !validateDescription) {
+    if (
+      !validateChangelog &&
+      !validateCredits &&
+      !validateDescription &&
+      !validatePRTemplateSections.length
+    ) {
       core.info("PR validation is disabled");
       return;
     }
@@ -70,6 +77,20 @@ export default class PRValidation {
       if (!description.length) {
         failed = true;
         errors.push("Please add some description about the changes made in PR");
+      }
+    }
+
+    if (validatePRTemplateSections.length) {
+      core.info("Running PR template section validation");
+      for (const heading of validatePRTemplateSections) {
+        const content = getSectionContent(pullRequest, heading);
+        core.debug(`Section "${heading}": ${content}`);
+        if (!content.length) {
+          failed = true;
+          errors.push(
+            `Please fill out the **${heading}** section of the PR template`
+          );
+        }
       }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,13 @@ export function getInputs(pullRequest = {}) {
     core.getInput("comment-template") === "false"
       ? false
       : core.getInput("comment-template") ||
-        "{author} thanks for the PR! Could you please fill out the PR template with description, changelog, and credits information so that we can properly review and merge this?";
+        "{author} thanks for the PR! Could you please fill out the PR template so that we can properly review and merge this?";
+
+  // PR template section validation
+  const rawTemplateSections = core.getMultilineInput("validate-pr-template-sections") || [];
+  const validatePRTemplateSections = rawTemplateSections
+    .map((s) => s.replace(/^#+\s*/, "").trim())
+    .filter(Boolean);
 
   // Welcome message inputs
   const issueWelcomeMessage =
@@ -133,9 +139,13 @@ export function getInputs(pullRequest = {}) {
     `PR Welcome Message: ${prWelcomeMessage} (${typeof prWelcomeMessage})`
   );
   core.debug(`Ignore Users: ${ignoreUsers} (${typeof ignoreUsers})`);
+  core.debug(
+    `Validate PR Template Sections: ${validatePRTemplateSections} (${typeof validatePRTemplateSections})`
+  );
 
   return {
     assignIssues,
+    validatePRTemplateSections,
     addMilestone,
     assignPullRequest,
     validateChangelog,
@@ -220,6 +230,44 @@ export function getChangelog(payload) {
   }
 
   return entries.filter((entry) => entry.length > 0);
+}
+
+/**
+ * Get the content under a specific section heading in the PR body.
+ * Matches any heading level (e.g. #, ##, ###) followed by the given heading text.
+ *
+ * @param {object} payload     Pull request payload
+ * @param {string} headingName Section heading text, without leading # markers
+ * @returns string
+ */
+export function getSectionContent(payload, headingName) {
+  const cleanBody = removeHtmlComments(payload?.body || "");
+  const lines = cleanBody.split(/\r?\n/);
+  let inSection = false;
+  const content = [];
+
+  for (const line of lines) {
+    const isHeading = /^#{1,6}\s+/.test(line);
+    if (isHeading) {
+      // Stop collecting once we hit the next heading after our target.
+      if (inSection) {
+        break;
+      }
+      // Start collecting if this heading matches the target (any level).
+      if (line.replace(/^#{1,6}\s+/, "").trim() === headingName) {
+        inSection = true;
+      }
+      continue;
+    }
+    if (inSection) {
+      content.push(line);
+    }
+  }
+
+  return content
+    .filter((line) => !/^>\s/.test(line))
+    .join("\n")
+    .trim();
 }
 
 /**


### PR DESCRIPTION
## Description of the Change

Introduces a new `validate-pr-template-sections` input that accepts a multiline list of PR template section headings to require non-empty content under. This allows repositories with custom PR templates to validate that specific sections have been filled out, without being tied to the hardcoded `Description of the Change`, `Changelog`, and `Credits` headings used by the existing validation inputs.

Key behaviors:
- Heading level is ignored — `What?`, `## Why?`, and `### Use of AI Tools` all match the same heading text
- Content consisting only of whitespace or blockquote lines (`> ...`) is treated as empty, handling placeholder examples common in PR templates
- Each failing section produces a distinct error message
- Fully backward compatible — existing `validate-description`, `validate-changelog`, and `validate-credits` inputs are unchanged
- Also updates the default `comment-template` wording to be generic rather than referencing 10up-specific section names

## Changelog

Added - New `validate-pr-template-sections` input for configurable PR template section validation.

## Credits

@jeffpaul